### PR TITLE
Update objdump example to use latest elf crate v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ pledge = "0.4"
 
 [dev-dependencies]
 env_logger = "0.9"
-elf = "0.0.10"
+elf = "0.7.0"
 ctrlc = "3.1.0"
 rustls = "0.20"
 sha2 = "0.10"

--- a/examples/objdump.rs
+++ b/examples/objdump.rs
@@ -20,8 +20,9 @@ enum Encoding {
 impl Encoding {
     fn encode(&self, data: &[u8]) -> String {
         match &self {
-            Encoding::Hex => data.iter()
-                    .fold(String::new(), |a, b| a + &format!("\\x{:02x}", b)),
+            Encoding::Hex => data
+                .iter()
+                .fold(String::new(), |a, b| a + &format!("\\x{:02x}", b)),
             Encoding::Base64 => base64::encode(data),
         }
     }
@@ -36,12 +37,27 @@ fn main() -> Result<()> {
         Encoding::Base64
     };
 
-    let file = elf::File::open_path(&args.path)
-        .map_err(|e| anyhow!("Couldn't open file: {:?}", e))?;
-    let section = file.get_section(".text")
-        .context("Couldn't find .text section")?;
+    let file = std::fs::File::open(&args.path)?;
 
-    let shellcode = encoding.encode(&section.data);
+    // Use a lazy i/o ElfStream so that we only read the ELF sections that we're interested in.
+    // Makes this faster for large files where the .text section is small.
+    let mut elf = elf::ElfStream::<elf::endian::AnyEndian, _>::open_stream(&file)?;
+
+    let section = *elf
+        .section_header_by_name(".text")?
+        .expect("Could not find .text section");
+
+    // Note: section_data() returns an optional compression context alongside the data
+    // which informs if and how the data was compressed.
+    // Typically, this is only done for debug info sections.
+    let section_data = match elf.section_data(&section)? {
+        (section_data, None) => section_data,
+        _ => {
+            panic!("Cannot dump compressed .text section");
+        }
+    };
+
+    let shellcode = encoding.encode(section_data);
     println!("{}", shellcode);
 
     Ok(())


### PR DESCRIPTION
I made a bunch of improvements to the elf crate and am going around finding example usages of the old version and updating them. Mostly just as a means of providing updated examples in the wild for folks who are looking to use the new interface.